### PR TITLE
interceptor: add logging to interceptor invoke-stage calls

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,18 +1,32 @@
 (defproject exoscale/interceptor "0.1.10-SNAPSHOT"
   :license {:name "ISC"}
   :url "https://github.com/exoscale/interceptor"
-  :dependencies [[org.clojure/clojure "1.10.1"]]
+  :dependencies [[org.clojure/clojure "1.10.1"]
+                 [org.clojure/tools.logging "1.1.0"]]
   :deploy-repositories [["snapshots" :clojars] ["releases" :clojars]]
-  :profiles {:dev
+  :profiles {:test
+             {:dependencies [[ch.qos.logback/logback-classic "1.1.3"]]
+              :jvm-opts ["-Dclojure.tools.logging.factory=clojure.tools.logging.impl/slf4j-factory"]}
+
+             :dev
              {:dependencies [[org.clojure/clojurescript "1.10.439"]
                              [manifold "0.1.8"]
                              [org.clojure/core.async "0.4.500"]
-                             [cc.qbits/auspex "0.1.0-alpha2"]]
+                             [cc.qbits/auspex "0.1.0-alpha2"]
+                             ;;bench+logging
+                             [spootnik/unilog "0.7.24"
+                              :exclusions [ch.qos.logback/logback-classic
+                                           ch.qos.logback/logback-core
+                                           com.fasterxml.jackson.core/jackson-core]]
+                             [ch.qos.logback/logback-classic "1.1.3"]
+                             [ch.qos.logback/logback-core "1.1.3"]]
+              :jvm-opts ["-Dclojure.tools.logging.factory=clojure.tools.logging.impl/slf4j-factory"]
               :plugins [[lein-cljsbuild "1.1.7"]]
-
               :cljsbuild {:builds
                           [{:id "default"
                             :source-paths ["src"]
                             :compiler {:optimizations :whitespace
                                        :pretty-print true}}]}}}
+  :cljsbuild {:repl-listen-port 9000
+              :repl-launch-commands {"ffox" ["firefox" "-jsconsole"]}}
   :pedantic? :warn)

--- a/src/exoscale/interceptor.cljc
+++ b/src/exoscale/interceptor.cljc
@@ -1,7 +1,9 @@
 (ns exoscale.interceptor
   (:refer-clojure :exclude [when])
   (:require [exoscale.interceptor.impl :as impl]
-            [exoscale.interceptor.protocols :as p]))
+            [exoscale.interceptor.protocols :as p]
+            #?(:clj  [clojure.tools.logging :refer [debug debugf]])
+            #?(:cljs [exoscale.interceptor.nop-logger :refer [debug debugf]])))
 
 ;;; API
 

--- a/src/exoscale/interceptor/nop_logger.cljc
+++ b/src/exoscale/interceptor/nop_logger.cljc
@@ -1,0 +1,18 @@
+(ns exoscale.interceptor.nop-logger
+  "Nop logger for clojurescript")
+
+;; same macros as clojure.tools.logging
+(defmacro trace [& args])
+(defmacro debug [& args])
+(defmacro info [& args])
+(defmacro warn [& args])
+(defmacro error [& args])
+(defmacro fatal [& args])
+
+(defmacro tracef [& args])
+(defmacro debugf [& args])
+(defmacro infof [& args])
+(defmacro warnf [& args])
+(defmacro errorf [& args])
+(defmacro fatalf [& args])
+

--- a/test/exoscale/interceptor_test.clj
+++ b/test/exoscale/interceptor_test.clj
@@ -8,7 +8,8 @@
             [qbits.auspex :as q]
             [clojure.core.async :as a]))
 
-(def iinc {:error (fn [ctx err]
+(def iinc {:name "iinc"
+           :error (fn [ctx err]
                     ctx)
            :enter (fn [ctx]
                     (update ctx :a inc))
@@ -343,3 +344,4 @@
                            ;; just to make sure we preserve chaining
                            {:enter (fn [ctx] (assoc ctx :g 7))}])
              (select-keys [:a :b :c :d :e :f :g])))))
+


### PR DESCRIPTION
By enabling `:debug` level on interceptor, we can identify what interceptor failed when processing a chain:

```
...
18:31:25.838 | d-pool-3-2 | DEBUG | Invoking stage :enter of interceptor <unnamed>
18:31:25.888 | d-pool-3-2 | DEBUG | Invoking stage :enter of interceptor :my.interceptor/validate-account
18:31:25.899 | d-pool-3-2 |  WARN | Account not found: 1234567e-c6ac-4e25-8567-357daf82555c
18:31:25.900 | d-pool-3-4 | DEBUG | Invoking stage :error of interceptor :my.error.interceptor/error
18:31:25.901 | d-pool-3-4 | DEBUG | Invoking stage :leave of interceptor :my.interceptor/format-leave
18:31:25.901 | d-pool-3-4 | DEBUG | Invoking stage :leave of interceptor :my.interceptor/logger
18:31:25.901 | d-pool-3-4 |  INFO | :post /template/register status 400 [66ms]
```

We can easily identify what interceptor triggered the `:error` processing