### PR TITLE
[wip] some utils to enable tracing/timings/logging

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,8 @@
              {:dependencies [[org.clojure/clojurescript "1.10.439"]
                              [manifold "0.1.8"]
                              [org.clojure/core.async "0.4.500"]
-                             [cc.qbits/auspex "0.1.0-alpha2"]]
+                             [cc.qbits/auspex "0.1.0-alpha2"]
+                             [org.clojure/tools.logging "1.1.0"]]
               :plugins [[lein-cljsbuild "1.1.7"]]
 
               :cljsbuild {:builds

--- a/src/exoscale/interceptor.cljc
+++ b/src/exoscale/interceptor.cljc
@@ -73,6 +73,28 @@
 
 ;;; helpers/middlewares
 
+(defn wrap
+  "Runs `before` before the stage function runs, then `after` before we
+  return the new modified context"
+  [f {:keys [before after]
+      :or {before identity
+           after identity}}]
+  (fn [ctx]
+    (let [x (f (before ctx))]
+      (if (p/async? x)
+        (p/then x #(after %))
+        (after x)))))
+
+(defn before
+  "Wraps stage fn with another one"
+  [f before-f]
+  (wrap f {:before before-f}))
+
+(defn after
+  "Modifies context after stage function ran"
+  [f before-f]
+  (wrap f {:after before-f}))
+
 (defn transform
   "Takes stage function, and wraps it with callback that will return a
   new context from the application of `f'` onto it. It can be useful

--- a/src/exoscale/interceptor.cljc
+++ b/src/exoscale/interceptor.cljc
@@ -79,11 +79,17 @@
   [f {:keys [before after]
       :or {before identity
            after identity}}]
-  (fn [ctx]
-    (let [x (f (before ctx))]
-      (if (p/async? x)
-        (p/then x #(after %))
-        (after x)))))
+  (fn
+    ([ctx]
+     (let [x (f (before ctx))]
+       (if (p/async? x)
+         (p/then x #(after %))
+         (after x))))
+    ([ctx err]
+     (let [x (f (before ctx) err)]
+       (if (p/async? x)
+         (p/then x #(after %))
+         (after x))))))
 
 (defn before
   "Wraps stage fn with another one"

--- a/src/exoscale/interceptor/utils.clj
+++ b/src/exoscale/interceptor/utils.clj
@@ -1,0 +1,41 @@
+(ns exoscale.interceptor.utils
+  "Terrible namespace name, to be changed"
+  (:require [exoscale.interceptor :as ix]
+            [exoscale.interceptor.protocols :as p]))
+
+(defn- time-as
+  [k]
+  (fn [ctx] (assoc ctx k (java.time.Instant/now))))
+
+(defn with-timer
+  "Wrap every stage on every interceptor in a chain with timers"
+  [chain]
+  (into []
+        (comp (map p/interceptor)
+              (map (fn [{:as ix :keys [enter leave error name]
+                         :or {name ix}}]
+                     (cond-> ix
+                       (ifn? enter)
+                       (assoc :enter
+                              (ix/wrap enter
+                                       {:before (time-as [name ::enter ::start])
+                                        :after (time-as [name ::enter ::end])}))
+
+                       (ifn? leave)
+                       (assoc :leave
+                              (ix/wrap leave
+                                       {:before (time-as [name ::leave ::start])
+                                        :after (time-as [name ::leave ::end])}))
+
+                       (ifn? error)
+                       (assoc :error
+                              (ix/wrap error
+                                       {:before (time-as [name ::error ::start])
+                                        :after (time-as [name ::error ::end])}))))))
+        chain))
+
+(comment
+  (def inc-a (fn [ctx] (update ctx :a inc)))
+  (def inc-b #'inc-a)
+  (def inc-c #'inc-a)
+  (ix/execute {:a 1} (with-timer [inc-a inc-b inc-c])))

--- a/src/exoscale/interceptor/utils.clj
+++ b/src/exoscale/interceptor/utils.clj
@@ -1,6 +1,7 @@
 (ns exoscale.interceptor.utils
   "Terrible namespace name, to be changed"
   (:require [exoscale.interceptor :as ix]
+            [clojure.tools.logging :as log]
             [exoscale.interceptor.protocols :as p]))
 
 (defn- time-as
@@ -34,8 +35,45 @@
                                         :after (time-as [name ::error ::end])}))))))
         chain))
 
-(comment
+(defn- log-as
+  [k {:as _opts :keys [level fmt]
+      :or {level :debug
+           fmt (fn [ctx k] k)}}]
+  (fn [ctx]
+    (log/ level (fmt ctx k))
+    ctx))
+
+(defn with-log
+  ([chain] (with-log chain {}))
+  ([chain opts]
+   (into []
+         (comp (map p/interceptor)
+               (map (fn [{:as ix :keys [enter leave error name]
+                          :or {name ix}}]
+                      (cond-> ix
+                        (ifn? enter)
+                        (assoc :enter
+                               (ix/wrap enter
+                                        {:before (log-as [name ::enter] opts)
+                                         :after (log-as [name ::enter] opts)}))
+
+                        (ifn? leave)
+                        (assoc :leave
+                               (ix/wrap leave
+                                        {:before (log-as [name ::leave] opts)
+                                         :after (log-as [name ::leave] opts)}))
+
+                        (ifn? error)
+                        (assoc :error
+                               (ix/wrap error
+                                        {:before (log-as [name ::error] opts)
+                                         :after (log-as [name ::error] opts)}))))))
+         chain)))
+
+(do
   (def inc-a (fn [ctx] (update ctx :a inc)))
   (def inc-b #'inc-a)
   (def inc-c #'inc-a)
-  (ix/execute {:a 1} (with-timer [inc-a inc-b inc-c])))
+  (prn  (ix/execute {:a 1} (-> [inc-a inc-b inc-c]
+                               (with-timer)
+                               (with-log)))))


### PR DESCRIPTION
- [x] add before/after/wrap fns
- [ ] add stage middleware that adds timings to context
- [ ] add stage middlware that logs the timings right after we set them to the context ( could be an opt of the previous middleware or not )
- [ ] add stage middleware that just logs the name of the interceptor + stable being run (before, after)


[edit] we might actually want to change all of this to be done following opentracing spec, or at least stay close to it so that we can interop with it down the road.
