### PR TITLE
bug: ensure CompletableFuture can be used on the manifold interceptor chain

### DIFF
--- a/src/exoscale/interceptor/manifold.clj
+++ b/src/exoscale/interceptor/manifold.clj
@@ -2,10 +2,16 @@
   "Manifold support"
   (:require [exoscale.interceptor.protocols :as p]
             [exoscale.interceptor.impl :as impl]
-            [manifold.deferred :as d]))
+            [manifold.deferred :as d])
+  (:import (java.util.concurrent CompletableFuture)))
 
 (extend-protocol p/AsyncContext
   manifold.deferred.IDeferred
+  (then [d f] (d/chain' d f))
+  (catch [d f] (d/catch' d f)))
+
+(extend-protocol p/AsyncContext
+  CompletableFuture
   (then [d f] (d/chain' d f))
   (catch [d f] (d/catch' d f)))
 

--- a/test/exoscale/interceptor_test.clj
+++ b/test/exoscale/interceptor_test.clj
@@ -6,7 +6,8 @@
             [exoscale.interceptor.auspex :as ixq]
             [manifold.deferred :as d]
             [qbits.auspex :as q]
-            [clojure.core.async :as a]))
+            [clojure.core.async :as a])
+  (:import (java.util.concurrent CompletableFuture)))
 
 (def iinc {:error (fn [ctx err]
                     ctx)
@@ -109,6 +110,11 @@
 (deftest manifold-test
   (let [dinc {:enter (fn [ctx] (d/success-deferred (update ctx :a inc)))
               :leave (fn [ctx] (d/success-deferred (update ctx :b inc)))}]
+
+    (testing "CompletableFutures implement AsyncContext"
+      (is (= 1 @(ix/execute {} [(constantly (CompletableFuture/completedFuture 1))])))
+
+      (is (thrown? IllegalArgumentException @(ix/execute {} (constantly (CompletableFuture/failedFuture (IllegalArgumentException. "failed")))))))
 
     (is (= default-result
            (-> @(ix/execute start-ctx


### PR DESCRIPTION
@jeromer caught a bug where we were using `auspex` for timeouts, and the interceptor chain was not waiting for the CF to terminate, because `CompletableFuture` does ǹot satisfy `AsyncContext`.

This will enforce the minimum Java version to 1.8, because of the `import` (CF's are only available from java 1.8).