### PR TITLE
wrap comeback

### DIFF
--- a/src/exoscale/interceptor.cljc
+++ b/src/exoscale/interceptor.cljc
@@ -122,7 +122,8 @@
 ;;; stage middlewares
 
 (defn before-stage
-  "Wraps stage fn with another one"
+  "Wraps stage fn with another one, basically a middleware that will be run before
+  a stage"
   [f before-f]
   (fn
     ([ctx] (f (before-f ctx)))
@@ -145,7 +146,10 @@
 
 (defn into-stages
   "Applies fn `f` on all `stages` (collection of :enter, :leave and/or :error) of
-  `chain`. Useful when use in conjunction with, `after-stage`, `before-stage`.
+  `chain`. This provides a way to apply middlewares to an entire interceptor
+  chain at definition time.
+
+  Useful when used in conjunction with, `after-stage`, `before-stage`.
 
   `f` will be a function of a `stage` function, such as the ones returned by
   `before-stage`, `after-stage` and an `execution context`. The stage function

--- a/src/exoscale/interceptor.cljc
+++ b/src/exoscale/interceptor.cljc
@@ -124,7 +124,9 @@
 (defn wrap-stage
   "Runs `before` before the stage function runs, then `after` before we
   return the new modified context, takes the same arg as a potential
-  stage, so either 1 or 2 depending on enter/leave or error stages."
+  stage, so either 1 or 2 depending on `enter`/`leave` or `error`
+  stages. The `before` `after` fns can return any valid ctx
+  value (they are sync/async agnostic)"
   [f {:keys [before after]}]
   (fn
     ([ctx]

--- a/src/exoscale/interceptor.cljc
+++ b/src/exoscale/interceptor.cljc
@@ -169,7 +169,9 @@
   has to be used for all stage types. The execution context will
   contain an `:interceptor` key with the value for the current
   interceptor and `:stage` to indicate which stage we're at (enter,
-  leave or error)."
+  leave or error).
+
+  `(into-chain [...] [:enter :error] (fn [f execution-ctx] (after-stage f (fn [...] ...))))"
   [chain stages f]
   (into []
         (comp (map p/interceptor)

--- a/src/exoscale/interceptor.cljc
+++ b/src/exoscale/interceptor.cljc
@@ -160,7 +160,7 @@
   interceptor and `:stage` to indicate which stage we're at (enter, leave or
   error).
 
-  `(into-chain [...] [:enter :error] (fn [stage-f execution-ctx] (after-stage stage-f (fn [...] ...))))"
+  `(into-stages [...] [:enter :error] (fn [stage-f execution-ctx] (after-stage stage-f (fn [...] ...))))"
   [chain stages f]
   (into []
         (comp (map p/interceptor)

--- a/src/exoscale/interceptor.cljc
+++ b/src/exoscale/interceptor.cljc
@@ -119,6 +119,10 @@
   (transform f (fn [ctx _] ctx)))
 
 
+(defn current-stage
+  [ctx]
+  )
+
 ;;; stage middlewares
 
 (defn wrap-stage
@@ -185,11 +189,3 @@
                              ix
                              stages))))
         chain))
-
-;; (defn log-chain-execution
-;;   [chain]
-;;   (into-stages chain
-;;                [:enter :leave :error]
-;;                (wrap-stage {:before (fn ([ctx] (prn :)))})
-;;                )
-;;   )

--- a/src/exoscale/interceptor.cljc
+++ b/src/exoscale/interceptor.cljc
@@ -144,18 +144,17 @@
          (after-f ctx err))))))
 
 (defn into-stages
-  "Applies fn `f` on all `stages` of `chain`. Useful when use in
-  conjunction with, `after-stage`, `before-stage`.
+  "Applies fn `f` on all `stages` (collection of :enter, :leave and/or :error) of
+  `chain`. Useful when use in conjunction with, `after-stage`, `before-stage`.
 
-  `f` will be a function of a `stage` function, such as the ones
-  returned by `before-stage`, `after-stage` and an
-  `execution context`. The stage function is a normal interceptor
-  stage function, taking 1 or 2 arg depending on stage of
-  execution (enter/leave or error), can potentially be multi-arg if it
-  has to be used for all stage types. The execution context will
-  contain an `:interceptor` key with the value for the current
-  interceptor and `:stage` to indicate which stage we're at (enter,
-  leave or error).
+  `f` will be a function of a `stage` function, such as the ones returned by
+  `before-stage`, `after-stage` and an `execution context`. The stage function
+  is a normal interceptor stage function, taking 1 or 2 args depending on stage
+  of execution (enter/leave or error, error taking 2 args), can potentially be
+  multi-arg if it has to be used for all stage types. The execution context is a
+  map that will contain an `:interceptor` key with the value for the current
+  interceptor and `:stage` to indicate which stage we're at (enter, leave or
+  error).
 
   `(into-chain [...] [:enter :error] (fn [stage-f execution-ctx] (after-stage stage-f (fn [...] ...))))"
   [chain stages f]

--- a/src/exoscale/interceptor.cljc
+++ b/src/exoscale/interceptor.cljc
@@ -146,7 +146,8 @@
      (let [x (cond-> ctx (ifn? before) (before err))]
        (if (p/async? x)
          (cond-> x
-           (ifn? after) (p/then #(after % err)))
+           (ifn? after)
+           (p/then #(after % err)))
          (cond-> x
            (ifn? after)
            (after err)))))))
@@ -175,7 +176,7 @@
   interceptor and `:stage` to indicate which stage we're at (enter,
   leave or error).
 
-  `(into-chain [...] [:enter :error] (fn [f execution-ctx] (after-stage f (fn [...] ...))))"
+  `(into-chain [...] [:enter :error] (fn [stage-f execution-ctx] (after-stage f (fn [...] ...))))"
   [chain stages f]
   (into []
         (comp (map p/interceptor)

--- a/test/exoscale/interceptor_test.clj
+++ b/test/exoscale/interceptor_test.clj
@@ -352,13 +352,13 @@
     (is (= 2 (-> (ix/execute {:x 0}
                              (ix/into-stages [f f]
                                              []
-                                             #(ix/before-stage % m)))
+                                             #(fn [_ s] (ix/before-stage s m))))
                  :x))
         "does nothing")
     (is (= 0 (-> (ix/execute {:x 0}
                              (ix/into-stages [f f]
                                              [:enter]
-                                             #(ix/before-stage % m)))
+                                             (fn [_ s] (ix/before-stage s m))))
                  :x))
         "decs before incs on enter")
 
@@ -366,7 +366,7 @@
                              (ix/into-stages [{:enter f :leave f}
                                               {:enter f :leave f}]
                                              [:enter]
-                                             #(ix/before-stage % m)))
+                                             (fn [_ s] (ix/before-stage s m))))
                  :x))
         "decs before incs on enter, not on leave")
 
@@ -384,8 +384,9 @@
                                                         ctx)}
                                               f
                                               f
-                                              {:enter (fn [ctx] (throw (ex-info "boom" {})))}]
+                                              {:enter (fn [_ctx] (throw (ex-info "boom" {})))}]
                                              [:error]
-                                             #(ix/after-stage % (fn [ctx err] (m ctx)))))
+                                             (fn [_ s]
+                                               (ix/after-stage s (fn [ctx _err] (m ctx))))))
                  :x))
         "first f incs, second too, third blows up, error stage decrs")))

--- a/test/exoscale/interceptor_test.clj
+++ b/test/exoscale/interceptor_test.clj
@@ -379,8 +379,7 @@
         "decs before incs on enter and on leave")
 
     (is (= 1 (-> (ix/execute {:x 0}
-                             (ix/into-stages [{:error (fn [ctx e]
-                                                        (prn :here e)
+                             (ix/into-stages [{:error (fn [ctx _e]
                                                         ctx)}
                                               f
                                               f

--- a/test/exoscale/interceptor_test.clj
+++ b/test/exoscale/interceptor_test.clj
@@ -352,13 +352,13 @@
     (is (= 2 (-> (ix/execute {:x 0}
                              (ix/into-stages [f f]
                                              []
-                                             #(fn [_ s] (ix/before-stage s m))))
+                                             #(fn [s _] (ix/before-stage s m))))
                  :x))
         "does nothing")
     (is (= 0 (-> (ix/execute {:x 0}
                              (ix/into-stages [f f]
                                              [:enter]
-                                             (fn [_ s] (ix/before-stage s m))))
+                                             (fn [s _] (ix/before-stage s m))))
                  :x))
         "decs before incs on enter")
 
@@ -366,7 +366,7 @@
                              (ix/into-stages [{:enter f :leave f}
                                               {:enter f :leave f}]
                                              [:enter]
-                                             (fn [_ s] (ix/before-stage s m))))
+                                             (fn [s _] (ix/before-stage s m))))
                  :x))
         "decs before incs on enter, not on leave")
 
@@ -374,7 +374,7 @@
                              (ix/into-stages [{:enter f :leave f}
                                               {:enter f :leave f}]
                                              [:enter :leave]
-                                             #(ix/before-stage % m)))
+                                             (fn [s _] (ix/before-stage s m))))
                  :x))
         "decs before incs on enter and on leave")
 
@@ -386,7 +386,7 @@
                                               f
                                               {:enter (fn [_ctx] (throw (ex-info "boom" {})))}]
                                              [:error]
-                                             (fn [_ s]
+                                             (fn [s _]
                                                (ix/after-stage s (fn [ctx _err] (m ctx))))))
                  :x))
         "first f incs, second too, third blows up, error stage decrs")))

--- a/test/exoscale/interceptor_test.clj
+++ b/test/exoscale/interceptor_test.clj
@@ -1,5 +1,5 @@
 (ns exoscale.interceptor-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [is deftest]]
             [exoscale.interceptor :as ix]
             [exoscale.interceptor.manifold :as ixm]
             [exoscale.interceptor.core-async :as ixa]
@@ -325,8 +325,8 @@
 (deftest transform-test
   (is (= {:a 1 :b 2 :c 3}
          (-> @(ix/execute {:a 1}
-                       [{:enter (-> (fn [ctx] (d/success-deferred (assoc ctx :c 3)))
-                                    (ix/transform (fn [ctx x] (merge ctx x {:b 2}))))}])
+                          [{:enter (-> (fn [ctx] (d/success-deferred (assoc ctx :c 3)))
+                                       (ix/transform (fn [ctx x] (merge ctx x {:b 2}))))}])
              (select-keys [:a :b :c]))))
   (is (= {:a 1 :b 2 :c 3}
          (-> (ix/execute {:a 1}
@@ -343,3 +343,49 @@
                            ;; just to make sure we preserve chaining
                            {:enter (fn [ctx] (assoc ctx :g 7))}])
              (select-keys [:a :b :c :d :e :f :g])))))
+
+
+(deftest wrap-test
+  (let [f #(update % :x inc)
+        m #(update % :x dec)]
+
+    (is (= 2 (-> (ix/execute {:x 0}
+                             (ix/into-stages [f f]
+                                             []
+                                             #(ix/before-stage % m)))
+                 :x))
+        "does nothing")
+    (is (= 0 (-> (ix/execute {:x 0}
+                             (ix/into-stages [f f]
+                                             [:enter]
+                                             #(ix/before-stage % m)))
+                 :x))
+        "decs before incs on enter")
+
+    (is (= 2 (-> (ix/execute {:x 0}
+                             (ix/into-stages [{:enter f :leave f}
+                                              {:enter f :leave f}]
+                                             [:enter]
+                                             #(ix/before-stage % m)))
+                 :x))
+        "decs before incs on enter, not on leave")
+
+    (is (= 0 (-> (ix/execute {:x 0}
+                             (ix/into-stages [{:enter f :leave f}
+                                              {:enter f :leave f}]
+                                             [:enter :leave]
+                                             #(ix/before-stage % m)))
+                 :x))
+        "decs before incs on enter and on leave")
+
+    (is (= 1 (-> (ix/execute {:x 0}
+                             (ix/into-stages [{:error (fn [ctx e]
+                                                        (prn :here e)
+                                                        ctx)}
+                                              f
+                                              f
+                                              {:enter (fn [ctx] (throw (ex-info "boom" {})))}]
+                                             [:error]
+                                             #(ix/after-stage % (fn [ctx err] (m ctx)))))
+                 :x))
+        "first f incs, second too, third blows up, error stage decrs")))


### PR DESCRIPTION
Adds stage wrapping functions (basically stage middlewares). As a reminder a "stage" means a function like enter/leave/error. 

The use case is to be able to modify/wrap these functions for tracing/logging etc.

The goal is to do this while not touching impl.clj so not to add any overhead to execution for the common cases and defer all operations/decorators on the chain at the chain creation.

The current proposal adds a few functions that can be run against stage functions, these can apply :before a stage function runs, or :after. They take the current stage function as argument, nothing else. The would usually not need more as if they are used directly we know the location/execution context (which interceptor, which stage). 

We also add an `into-stages` function that takes a chain as argument, a collection of stage keys (enter, leave, error) and will apply `f` on all stages in the chain that matches the keys mentioned previously. That function will take 2 arguments, an execution context, a map (containing information about which interceptor is being modified, and what stage), and the stage function as second argument. Typically that `f` would call one of the wrapping functions mentioned earlier (or some custom code).

A very naive example that adds logging before all interceptor stages (enter, leave and error) with some info about execution context would look like this:

```clj

(defn log-chain-execution
  [chain]
  (ix/into-stages chain
                  [:enter :leave :error]
                  (fn [f {:keys [interceptor stage]}]
                    (-> f
                        (ix/before-stage (fn [ctx]
                                           (log/infof "ts before %s %s %s" stage on (:name interceptor) ...)
                                           ctx))
                        (ix/after-stage (fn [ctx]
                                           (log/infof "ts before %s %s %s" stage on (:name interceptor) ...)
                                          ctx ))))))
```






