### PR TITLE
add interceptor/remove

### DIFF
--- a/src/exoscale/interceptor.cljc
+++ b/src/exoscale/interceptor.cljc
@@ -67,17 +67,20 @@
          ::stack nil))
 
 (defn xform-stack
-  "Takes a context from execution and run xf on stack, returns a new context "
+  "Takes a context from execution and run xf (transducing fn) on stack, returns a
+  new context "
   [ctx xf]
   (update ctx ::stack #(into (empty %) xf %)))
 
 (defn xform-queue
-  "Takes a context from execution and run xf on queue, returns a new context "
+  "Takes a context from execution and run xf (transducing fn) on queue, returns a
+  new context "
   [ctx xf]
   (update ctx ::queue #(into (empty %) xf %)))
 
 (defn xform
-  "Takes a context from execution and run xf on stack/queue, returns a new context "
+  "Takes a context from execution and run xf (transducing fn) on stack/queue,
+  returns a new context "
   [ctx xf]
   (->> ctx
        (xform-queue xf)

--- a/src/exoscale/interceptor.cljc
+++ b/src/exoscale/interceptor.cljc
@@ -89,7 +89,7 @@
 (defn remove
   "Remove all interceptors matching predicate from stack/queue, returns context"
   [ctx pred]
-  (xform ctx #(clojure.core/remove pred)))
+  (xform ctx (clojure.core/remove pred)))
 
 (defn enqueue
   "Adds interceptors to current context"

--- a/src/exoscale/interceptor.cljc
+++ b/src/exoscale/interceptor.cljc
@@ -82,9 +82,9 @@
   "Takes a context from execution and run xf (transducing fn) on stack/queue,
   returns a new context "
   [ctx xf]
-  (->> ctx
-       (xform-queue xf)
-       (xform-stack xf)))
+  (-> ctx
+      (xform-queue xf)
+      (xform-stack xf)))
 
 (defn remove
   "Remove all interceptors matching predicate from stack/queue, returns context"

--- a/src/exoscale/interceptor.cljc
+++ b/src/exoscale/interceptor.cljc
@@ -1,5 +1,5 @@
 (ns exoscale.interceptor
-  (:refer-clojure :exclude [when])
+  (:refer-clojure :exclude [when remove])
   (:require [exoscale.interceptor.impl :as impl]
             [exoscale.interceptor.protocols :as p]))
 
@@ -66,6 +66,13 @@
          ::queue nil
          ::stack nil))
 
+(defn remove
+  "Remove all interceptors matching predicate from stack/queue, returns context"
+  [ctx pred]
+  (-> ctx
+      (update ::queue #(into (empty %) (clojure.core/remove pred) %))
+      (update ::stack #(into (empty %) (clojure.core/remove pred) %))))
+
 (defn enqueue
   "Adds interceptors to current context"
   [ctx interceptors]
@@ -117,7 +124,6 @@
   "Run function for side-effects only and return context"
   [f]
   (transform f (fn [ctx _] ctx)))
-
 
 ;;; stage middlewares
 

--- a/src/exoscale/interceptor.cljc
+++ b/src/exoscale/interceptor.cljc
@@ -66,12 +66,27 @@
          ::queue nil
          ::stack nil))
 
+(defn xform-stack
+  "Takes a context from execution and run xf on stack, returns a new context "
+  [ctx xf]
+  (update ctx ::stack #(into (empty %) xf %)))
+
+(defn xform-queue
+  "Takes a context from execution and run xf on queue, returns a new context "
+  [ctx xf]
+  (update ctx ::queue #(into (empty %) xf %)))
+
+(defn xform
+  "Takes a context from execution and run xf on stack/queue, returns a new context "
+  [ctx xf]
+  (->> ctx
+       (xform-queue xf)
+       (xform-stack xf)))
+
 (defn remove
   "Remove all interceptors matching predicate from stack/queue, returns context"
   [ctx pred]
-  (-> ctx
-      (update ::queue #(into (empty %) (clojure.core/remove pred) %))
-      (update ::stack #(into (empty %) (clojure.core/remove pred) %))))
+  (xform ctx #(clojure.core/remove pred)))
 
 (defn enqueue
   "Adds interceptors to current context"

--- a/test/exoscale/interceptor_test.clj
+++ b/test/exoscale/interceptor_test.clj
@@ -388,7 +388,13 @@
 
 (deftest chain-ops
   (let [chain [{:id ::foo :enter (fn [ctx] (ix/remove ctx #(contains? #{::bar1 ::bar2} (:id %))))}
-               {:id ::bar1 :enter (fn [_] :should-be-removed)}
-               {:id ::bar2 :enter (fn [_] :should-be-removed-too)}
+               {:id ::bar1
+                :enter (fn [_] :should-be-removed)
+                :leave (fn [_] :should-be-removed)
+                :error (fn [_] :should-be-removed)}
+               {:id ::bar2
+                :enter (fn [_] :should-be-removed)
+                :leave (fn [_] :should-be-removed)
+                :error (fn [_] :should-be-removed)}
                {:id ::baz :enter (fn [_] :works)}]]
     (is (= :works (ix/execute {} chain)))))


### PR DESCRIPTION
* `interceptor/remove` : removes all interceptors matching predicate from the chain at execution time,
so from both stack/queue

remove is built on:

* `interceptor/xform` : runs transducer fn against stack/queue in the running chain
* `interceptor/xform-stack` : runs transducer fn against stack in the running chain
* `interceptor/xform-queue` : runs transducer fn against queue in the running chain
