### PR TITLE
Fix Interceptor protocol for cljs types

### DIFF
--- a/src/exoscale/interceptor/impl.cljc
+++ b/src/exoscale/interceptor/impl.cljc
@@ -9,7 +9,8 @@
      :cljs cljs.core.PersistentHashMap)
   (interceptor [m] (map->Interceptor m))
 
-  clojure.lang.IRecord
+  #?(:clj clojure.lang.IRecord
+     :cljs cljs.core.IRecord)
   (interceptor [r] r)
 
   #?(:clj clojure.lang.Fn
@@ -17,11 +18,13 @@
   (interceptor [f]
     (p/interceptor {:enter f}))
 
-  clojure.lang.Keyword
+  #?(:clj clojure.lang.Keyword
+     :cljs cljs.core.Keyword)
   (interceptor [f]
     (p/interceptor {:enter f}))
 
-  clojure.lang.Var
+  #?(:clj clojure.lang.Var
+     :cljs cljs.core.Var)
   (interceptor [v]
     (p/interceptor (deref v))))
 


### PR DESCRIPTION
Hi there!

I recently started using your library, primarily in cljs to create interceptor chains around Datascript transactions.

I hit an issue where the Interceptor protocol wouldn't compile in cljs, because of the types which I've fixed in this PR. Please let me know if this is incorrect, happy to make adjustments as needed.