### PR TITLE
perf: improve general performance

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,10 +4,12 @@
   :dependencies [[org.clojure/clojure "1.11.1"]]
   :deploy-repositories [["snapshots" :clojars] ["releases" :clojars]]
   :profiles {:dev
-             {:dependencies [[org.clojure/clojurescript "1.11.54"]
+             {:source-paths ["dev"]
+              :dependencies [[org.clojure/clojurescript "1.11.54"]
                              [manifold "0.2.4"]
                              [org.clojure/core.async "1.5.648"]
-                             [cc.qbits/auspex "1.0.0-alpha9"]]
+                             [cc.qbits/auspex "1.0.0-alpha9"]
+                             [criterium "0.4.6"]]
               :plugins [[lein-cljsbuild "1.1.7"]]
 
               :cljsbuild {:builds

--- a/src/exoscale/interceptor/auspex.clj
+++ b/src/exoscale/interceptor/auspex.clj
@@ -9,6 +9,10 @@
   (then [d f] (auspex/chain d f))
   (catch [d f] (auspex/catch d f)))
 
+(extend-protocol p/InterceptorContext
+  java.util.concurrent.CompletableFuture
+  (async? [_] true))
+
 (defn execute
   "Like `exoscale.interceptor/execute` but ensures we always get a
   CompletableFuture back"

--- a/src/exoscale/interceptor/core_async.cljc
+++ b/src/exoscale/interceptor/core_async.cljc
@@ -48,6 +48,11 @@
                             (f %))))
            out-ch)))
 
+(extend-protocol p/InterceptorContext
+  #?(:cljs cljs.core.async.impl.channels.ManyToManyChannel
+     :clj clojure.core.async.impl.channels.ManyToManyChannel)
+  (async? [_] true))
+
 (defn execute
   "Like `exoscale.interceptor/execute` but ensures we always get a
   core.async channel back"

--- a/src/exoscale/interceptor/manifold.clj
+++ b/src/exoscale/interceptor/manifold.clj
@@ -9,6 +9,10 @@
   (then [d f] (d/chain' d f))
   (catch [d f] (d/catch' d f)))
 
+(extend-protocol p/InterceptorContext
+  manifold.deferred.IDeferred
+  (async? [_] true))
+
 (defn execute
   "Like `exoscale.interceptor/execute` but ensures we always get a
   manifold.Deferred back"

--- a/src/exoscale/interceptor/protocols.cljc
+++ b/src/exoscale/interceptor/protocols.cljc
@@ -4,9 +4,15 @@
   (then [x f])
   (catch [x f]))
 
-(defn async?
-  [x]
-  (satisfies? AsyncContext x))
+(defprotocol InterceptorContext
+  (async? [x]))
 
 (defprotocol Interceptor
   (interceptor [x] "Produces an interceptor from value"))
+
+(extend-protocol InterceptorContext
+  ;; we extend all Objects including Deferred, core.async channels and CompletableFuture
+  ;; but when their respective namespaces load, they will call extend-protocol
+  ;; thus implementing async? for their respective classes
+  Object
+  (async? [_] false))


### PR DESCRIPTION
The `(async?)` call is resolved through `satisifes?` and is being called several times per interceptor.
On a sufficient long chain, those calls add up and finding if an object implements a given protocol ends up taking some time.

Benchmarking shows around **5ms** on a chain with 100 interceptors:
```
(def ctx {:a 1})
(def sync-ix (into [] (repeat 100 (fn [ctx] (update ctx :a inc)))))
(def async-ix (into [] (repeat 100 (fn [ctx] (d/success-deferred (update ctx :a inc))))))

(comment
  (cc/quick-bench (ix/execute ctx sync-ix)) ;; Execution time mean : 5.580637 ms
  (cc/quick-bench (ixm/execute ctx async-ix))) ;; Execution time mean : 5.534618 ms
```

This PR makes sure sure the `async?` call responds as fast as possible.
Note that `async` is implemented twice for (eg:) deferreds, but the order of requires (`exoscale.interceptor.manifold` depends on  `exoscale.interceptor.protocols`) will ensure that the "correct" implementation wins.

| | before | after | improvement |
|-|----------|--------|--------|
| sync   | ~5.5ms | ~58.5 µs | ~94x faster |
| async | ~5.5ms | ~76.5 µs | ~70x faster |