### PR TITLE
Extending types and protocols in cljs use typeof name

### DIFF
--- a/src/exoscale/interceptor/impl.cljc
+++ b/src/exoscale/interceptor/impl.cljc
@@ -28,7 +28,7 @@
   (interceptor [v]
     (p/interceptor (deref v)))
 
-  Object
+  #?(:clj Object :cljs object)
   (interceptor [x]
     ;; Fallback : Could already be ILookup'able, would cover custom types (ex:
     ;; records)

--- a/src/exoscale/interceptor/protocols.cljc
+++ b/src/exoscale/interceptor/protocols.cljc
@@ -14,5 +14,5 @@
   ;; we extend all Objects including Deferred, core.async channels and CompletableFuture
   ;; but when their respective namespaces load, they will call extend-protocol
   ;; thus implementing async? for their respective classes
-  Object
+  #?(:clj Object :cljs object)
   (async? [_] false))


### PR DESCRIPTION
Was running into the following error in clojurescript:

![Screenshot from 2022-11-11 12-51-25](https://user-images.githubusercontent.com/467827/201399818-e02590fa-a944-43f5-a7a3-31feddd229bd.png)

the fix is to use `object` instead of `Object` to extend protocols.

see:
https://funcool.github.io/clojurescript-unraveled/#extending-existing-types