### PR TITLE
bug: ensure nil value also implements InterceptorContext

### DIFF
--- a/src/exoscale/interceptor/protocols.cljc
+++ b/src/exoscale/interceptor/protocols.cljc
@@ -7,6 +7,11 @@
 (defprotocol InterceptorContext
   (async? [x]))
 
+;; preserve the same behaviour as 0.1.14 (before we introduced InterceptorContext)
+(extend-protocol InterceptorContext
+  nil
+  (async? [_] false))
+
 (defprotocol Interceptor
   (interceptor [x] "Produces an interceptor from value"))
 

--- a/test/exoscale/interceptor_discard_test.clj
+++ b/test/exoscale/interceptor_discard_test.clj
@@ -1,0 +1,14 @@
+(ns exoscale.interceptor-discard-test
+  (:require [clojure.test :refer :all]
+            [exoscale.interceptor :as ix]))
+
+(deftest discard-can-return-nil-test
+  (testing "ix/discard doesnt return anything"
+    (let [f (fn [_] (println "fn called"))
+          test-ix {:name  ::ensure-body-closed
+                    :leave (-> f
+                               (ix/in [:a])
+                               (ix/discard))}]
+      (is (= {:a 1}
+             (-> (ix/execute {:a 1} [test-ix])
+                 (select-keys [:a])))))))

--- a/test/exoscale/interceptor_discard_test.clj
+++ b/test/exoscale/interceptor_discard_test.clj
@@ -5,7 +5,7 @@
 (deftest discard-can-return-nil-test
   (testing "ix/discard doesnt return anything"
     (let [f (fn [_] (println "fn called"))
-          test-ix {:name  ::ensure-body-closed
+          test-ix {:name  ::discard-ix
                     :leave (-> f
                                (ix/in [:a])
                                (ix/discard))}]


### PR DESCRIPTION
This is in line with previous behaviour (before introducing `InterceptorContext`). See #15 for more information